### PR TITLE
Download PAs

### DIFF
--- a/linklives-api/Controllers/PersonAppearanceController.cs
+++ b/linklives-api/Controllers/PersonAppearanceController.cs
@@ -1,6 +1,6 @@
 ﻿using Linklives.DAL;
 using Microsoft.AspNetCore.Mvc;
-using Linklives.Domain;
+using Linklives.Serialization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -52,8 +52,7 @@ namespace linklives_api.Controllers
                 return NotFound("No person appearance with that ID exists.");
             }
 
-            var serializable = new RowSerializable[] { personAppearance };
-            var rows = SpreadsheetSerializer.Serialize(serializable);
+            var rows = SpreadsheetSerializer.Serialize(personAppearance);
             var result = encoder.Encode(rows);
 
             return File(result, encoder.ContentType, $"personAppearance.{format}");

--- a/linklives-api/Controllers/PersonAppearanceController.cs
+++ b/linklives-api/Controllers/PersonAppearanceController.cs
@@ -1,6 +1,6 @@
 ﻿using Linklives.DAL;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
+using Linklives.Domain;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -32,6 +32,31 @@ namespace linklives_api.Controllers
                 return Ok(result);
             }
             return NotFound();
+        }
+
+        [HttpPost("{id}/download.{format}")]
+        [ResponseCache(CacheProfileName = "StaticLinkLivesData")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(206)]
+        [ProducesResponseType(404)]
+        public ActionResult Download(string id, string format)
+        {
+            var encoder = Encoder.ForFormat(format);
+            if (encoder == null) {
+                return NotFound("No formatter for that format exists.");
+            }
+
+            var personAppearance = repository.GetById(id);
+            if (personAppearance == null)
+            {
+                return NotFound("No person appearance with that ID exists.");
+            }
+
+            var serializable = new RowSerializable[] { personAppearance };
+            var rows = SpreadsheetSerializer.Serialize(serializable);
+            var result = encoder.Encode(rows);
+
+            return File(result, encoder.ContentType, $"personAppearance.{format}");
         }
     }
 }

--- a/linklives-api/Startup.cs
+++ b/linklives-api/Startup.cs
@@ -85,8 +85,8 @@ namespace linklives_api
             #endregion
             services.AddControllersWithViews()
                 .AddNewtonsoftJson(options =>
-                options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
-            );
+                    options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
+                );
 
             services.AddResponseCaching();
             services.AddControllers(options =>
@@ -114,7 +114,7 @@ namespace linklives_api
             {
                 options.UseMySQL(Configuration["LinkLives-DB-conn"]);
                 options.EnableSensitiveDataLogging();
-                });
+            });
             var settings = new ConnectionSettings(new Uri(Configuration["ElasticSearch-URL"]))
                 .RequestTimeout(TimeSpan.FromMinutes(2))
                 .DisableDirectStreaming();


### PR DESCRIPTION
This adds a /download.{format} (e.g. download.csv and download.xlsx) endpoint that allows the download of  a PA in a particular format.

Depends on changes in linklives-lib: https://github.com/CopenhagenCityArchives/linklives-lib/pull/1