### PR TITLE
Register downloads in history

### DIFF
--- a/linklives-api/Startup.cs
+++ b/linklives-api/Startup.cs
@@ -123,6 +123,7 @@ namespace linklives_api
             services.AddSingleton<ElasticClient>(new ElasticClient(settings));
 
             services.AddScoped<IEFLifeCourseRepository, EFLifeCourseRepository>();
+            services.AddScoped<IEFDownloadHistoryRepository, EFDownloadHistoryRepository>();
             services.AddScoped<IKeyedRepository<LifeCourse>, ESLifeCourseRepository>();
             services.AddScoped<ILinkRepository, EFLinkRepository>();
             services.AddScoped<ILinkRatingRepository, EFLinkRatingRepository>();


### PR DESCRIPTION
Uses new download history repo (c.f. https://github.com/CopenhagenCityArchives/linklives-lib/pull/5) to save history entries.

Is this enough that it will work in prod? Do I need to do anything else to make it work?