### PR TITLE
Odd fixes (1)

### DIFF
--- a/linklives-api/Controllers/LifeCourseController.cs
+++ b/linklives-api/Controllers/LifeCourseController.cs
@@ -74,7 +74,7 @@ namespace linklives_api.Controllers
                 return NotFound("No formatter for that format exists.");
             }
 
-            var lifecourse = repository.GetByKey(key);
+            var lifecourse = esRepository.GetByKey(key);
             if (lifecourse == null)
             {
                 return NotFound("No lifecourse with that key exists");

--- a/linklives-api/Controllers/SearchController.cs
+++ b/linklives-api/Controllers/SearchController.cs
@@ -21,18 +21,21 @@ namespace linklives_api.Controllers
     {
         private readonly ElasticClient client;
         private readonly IEFLifeCourseRepository lifecourseRepository;
+        private readonly IKeyedRepository<LifeCourse> esLifecourseRepository;
         private readonly IPersonAppearanceRepository paRepository;
         private readonly IEFDownloadHistoryRepository downloadHistoryRepository;
 
         public SearchController(
             ElasticClient client,
             IEFLifeCourseRepository lifecourseRepository,
+            IKeyedRepository<LifeCourse> esLifecourseRepository,
             IPersonAppearanceRepository paRepository,
             IEFDownloadHistoryRepository downloadHistoryRepository
         )
         {
             this.client = client;
             this.lifecourseRepository = lifecourseRepository;
+            this.esLifecourseRepository = esLifecourseRepository;
             this.paRepository = paRepository;
             this.downloadHistoryRepository = downloadHistoryRepository;
         }
@@ -101,7 +104,7 @@ namespace linklives_api.Controllers
                 .ToList();
 
             var pas = paRepository.GetByIds(paKeys);
-            var lifecourses = lifecourseRepository.GetByKeys(lifecourseKeys);
+            var lifecourses = esLifecourseRepository.GetByKeys(lifecourseKeys);
 
             foreach(var lifecourse in lifecourses) {
                 GetPAsLinksAndLinkRatings(lifecourse);

--- a/linklives-api/Controllers/SearchController.cs
+++ b/linklives-api/Controllers/SearchController.cs
@@ -67,7 +67,14 @@ namespace linklives_api.Controllers
                 return NotFound("No formatter for that format exists.");
             }
 
+            // If requested download size is greater than 500, clamp it at 500.
+            var requestedSize = data.Value<int>("size");
+            if(requestedSize >= 500) {
+                data["size"] = 500;
+            }
+
             var stringData = data.ToString(Newtonsoft.Json.Formatting.None);
+
             var response = client.LowLevel.Search<StringResponse>(indexes, PostData.String(stringData));
 
             if(response.HttpStatusCode >= 400 && response.HttpStatusCode < 500) {


### PR DESCRIPTION
- Limit search result max downloads to 500
- When getting multiple lifecourses (*and* when loading in links to them later) use the ES repository to get them.
  - My theory is that this will alleviate two things:
    1. The entity framework lifecourser epository `.GetByKeys` returns a lazy enumerable that keeps a data reader in the db open for longer, which means reading anything from the DB in the same request results in an error where "A data reader is already open for this connection". (Probably. Maybe.)
    2. The items returned from the same `.GetByKeys` are Entity Framework models. When we save download history entries in an API call where we have modified these (e.g. loading in links and populating them) this causes an error with primary keys already being in use. (Probably. Maybe.)